### PR TITLE
Add captcha validation for lobby creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,3 +35,12 @@ Team members join a temporary **lobby via code** and submit:
 | Backend     | [ASP.NET Core Web API](https://learn.microsoft.com/en-us/aspnet/core/) + C# |
 | Database    | [Supabase PostgreSQL](https://supabase.com/) |
 | ORM         | Entity Framework Core |
+
+## 🔐 CAPTCHA Setup
+
+To enable CAPTCHA protection when creating a lobby you must configure a Google reCAPTCHA v3 site key and secret.
+
+Set the following environment variables before running the app:
+
+- `NEXT_PUBLIC_RECAPTCHA_SITE_KEY` – your public site key used on the frontend
+- `CAPTCHA_SECRET_KEY` – the matching secret key used by the API

--- a/ScrumAPI/lobby-service/Controllers/LobbyController.cs
+++ b/ScrumAPI/lobby-service/Controllers/LobbyController.cs
@@ -9,16 +9,24 @@ namespace LobbyService.Controllers;
 public class LobbyController : ControllerBase
 {
     private readonly Services.LobbyService _lobbyService;
+    private readonly Services.CaptchaService _captchaService;
 
-    public LobbyController(Services.LobbyService lobbyService)
+    public LobbyController(Services.LobbyService lobbyService, Services.CaptchaService captchaService)
     {
         _lobbyService = lobbyService;
+        _captchaService = captchaService;
     }
 
     [HttpPost]
     [EnableRateLimiting("PerIpPolicy")]
-    public async Task<IActionResult> CreateLobby()
+    public async Task<IActionResult> CreateLobby([FromBody] CreateLobbyDTO dto)
     {
+        var isValid = await _captchaService.VerifyTokenAsync(dto.CaptchaToken);
+        if (!isValid)
+        {
+            return BadRequest(new { message = "Invalid CAPTCHA" });
+        }
+
         var lobby = await _lobbyService.CreateLobbyAsync();
         return Ok(lobby);
     }

--- a/ScrumAPI/lobby-service/Models/CreateLobbyDTO.cs
+++ b/ScrumAPI/lobby-service/Models/CreateLobbyDTO.cs
@@ -1,0 +1,9 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace LobbyService.Models;
+
+public class CreateLobbyDTO
+{
+    [Required]
+    public string CaptchaToken { get; set; } = "";
+}

--- a/ScrumAPI/lobby-service/Program.cs
+++ b/ScrumAPI/lobby-service/Program.cs
@@ -13,6 +13,7 @@ builder.Services.AddDbContext<LobbyDbContext>(options =>
 builder.Services.AddScoped<LobbyService.Services.LobbyService>();
 builder.Services.AddScoped<CodeService>();
 builder.Services.AddScoped<ConnectionChecker>();
+builder.Services.AddHttpClient<CaptchaService>();
 
 builder.Services.AddControllers();
 builder.Services.AddEndpointsApiExplorer();

--- a/ScrumAPI/lobby-service/Services/CaptchaService.cs
+++ b/ScrumAPI/lobby-service/Services/CaptchaService.cs
@@ -1,0 +1,42 @@
+using System.Net.Http.Json;
+using Microsoft.Extensions.Configuration;
+
+namespace LobbyService.Services;
+
+public class CaptchaService
+{
+    private readonly HttpClient _client;
+    private readonly string? _secret;
+
+    public CaptchaService(HttpClient client, IConfiguration configuration)
+    {
+        _client = client;
+        _secret = configuration["Captcha:Secret"] ?? configuration["CAPTCHA_SECRET_KEY"];
+    }
+
+    private record RecaptchaResponse(bool success);
+
+    public async Task<bool> VerifyTokenAsync(string token)
+    {
+        if (string.IsNullOrWhiteSpace(_secret))
+        {
+            return true;
+        }
+
+        var response = await _client.PostAsync(
+            "https://www.google.com/recaptcha/api/siteverify",
+            new FormUrlEncodedContent(new Dictionary<string, string>
+            {
+                ["secret"] = _secret,
+                ["response"] = token
+            }));
+
+        if (!response.IsSuccessStatusCode)
+        {
+            return false;
+        }
+
+        var result = await response.Content.ReadFromJsonAsync<RecaptchaResponse>();
+        return result?.success ?? false;
+    }
+}

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
+import Head from "next/head";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -22,11 +23,19 @@ export default function RootLayout({
 }: Readonly<{
   children: React.ReactNode;
 }>) {
+  const siteKey = process.env.NEXT_PUBLIC_RECAPTCHA_SITE_KEY;
   return (
     <html lang="en">
-      <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased`}
-      >
+      <Head>
+        {siteKey && (
+          <script
+            src={`https://www.google.com/recaptcha/api.js?render=${siteKey}`}
+            async
+            defer
+          ></script>
+        )}
+      </Head>
+      <body className={`${geistSans.variable} ${geistMono.variable} antialiased`}>
         {children}
       </body>
     </html>

--- a/frontend/src/services/ApiService.tsx
+++ b/frontend/src/services/ApiService.tsx
@@ -101,7 +101,7 @@ export const ApiService = {
     }
   },
   
-  createLobby: async (): Promise<Lobby> => {
+  createLobby: async (captchaToken: string): Promise<Lobby> => {
     if (typeof window !== 'undefined' && !ApiService.canCreateLobby()) {
       throw new Error('You can only create one lobby per minute. Please try again later.');
     }
@@ -111,6 +111,7 @@ export const ApiService = {
       headers: {
         'Content-Type': 'application/json',
       },
+      body: JSON.stringify({ captchaToken }),
     });
 
     if (!response.ok) {


### PR DESCRIPTION
## Summary
- enforce reCAPTCHA check when creating a lobby
- add CaptchaService for verifying tokens
- send captcha token from frontend and load script
- document CAPTCHA environment variables

## Testing
- `dotnet test ScrumAPI/lobby-service.Tests/lobby-service.Tests.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f58f7bf0483208f004531584e9385